### PR TITLE
PercentNextPVPRank Calculation

### DIFF
--- a/MorunoRank/MorunoRank.toc
+++ b/MorunoRank/MorunoRank.toc
@@ -1,6 +1,6 @@
 ## Title: MurunoRank
 ## Interface: 40200
 ## Notes: Shows Rank Progress
-## Version: 1.0
+## Version: 2.0
 
 core.lua

--- a/MorunoRank/core.lua
+++ b/MorunoRank/core.lua
@@ -85,8 +85,10 @@ function MorunoRank()
    
     if(PercentNextPVPRank<0) then PercentNextPVPRank=PercentNextPVPRank*-1;end;
  
-    SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns.." at "..PercentNextPVPRank.."%(Rank "..EarnedRank..")","emote");
-
+    SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns.." at (Rank "..EarnedRank..")","emote");
+-- SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns.." at "..PercentNextPVPRank.."%(Rank "..EarnedRank..")","emote");
+-- This is a temp fix
+   
 -- This is a reference to a verified calculation. Going to try and incorporate the 'RP gaming this week'. 
 -- /script P=(math.floor(GetPVPRankProgress(target)*10000))/100 W=UnitPVPRank("player") N=(W-6)*5000+5000*P/100 Q=(W-5)*5000-N*0.8 SendChatMessage("Rank Progress: "..P.."% ".."Current RP: "..N.." RP to next rank "..Q.."","emote")   
    

--- a/MorunoRank/core.lua
+++ b/MorunoRank/core.lua
@@ -85,7 +85,7 @@ function MorunoRank()
    
     if(PercentNextPVPRank<0) then PercentNextPVPRank=PercentNextPVPRank*-1;end;
  
-    SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns.." at (Rank "..EarnedRank..")","emote");
+    SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns..")","emote");
 -- SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns.." at "..PercentNextPVPRank.."%(Rank "..EarnedRank..")","emote");
 -- This is a temp fix
    

--- a/MorunoRank/core.lua
+++ b/MorunoRank/core.lua
@@ -83,15 +83,14 @@ function MorunoRank()
     EarnedRank = getCurrentRank(EEarns);
     PercentNextPVPRank=math.floor(((EEarns-getCurrentHP(EarnedRank))*100)/(getCurrentHP(UPVPRank+1)-getCurrentHP(UPVPRank)));
    
-    if(PercentNextPVPRank<0) then PercentNextPVPRank=PercentNextPVPRank;end;
+    if(PercentNextPVPRank<0) then PercentNextPVPRank=PercentNextPVPRank*-1;end;
  
-SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns.." at "..PercentNextPVPRank.."%(Rank "..EarnedRank..")","emote");
+    SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB)..","emote");
 -- SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns.." at "..PercentNextPVPRank.."%(Rank "..EarnedRank..")","emote");
 -- This is a temp fix
    
 -- This is a reference to a verified calculation. Going to try and incorporate the 'RP gaming this week'. 
 -- /script P=(math.floor(GetPVPRankProgress(target)*10000))/100 W=UnitPVPRank("player") N=(W-6)*5000+5000*P/100 Q=(W-5)*5000-N*0.8 SendChatMessage("Rank Progress: "..P.."% ".."Current RP: "..N.." RP to next rank "..Q.."","emote")   
-   
 end
 
 end)

--- a/MorunoRank/core.lua
+++ b/MorunoRank/core.lua
@@ -86,6 +86,9 @@ function MorunoRank()
     if(PercentNextPVPRank<0) then PercentNextPVPRank=PercentNextPVPRank*-1;end;
  
     SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns.." at "..PercentNextPVPRank.."%(Rank "..EarnedRank..")","emote");
+
+-- This is a reference to a verified calculation. Going to try and incorporate the 'RP gaming this week'. 
+-- /script P=(math.floor(GetPVPRankProgress(target)*10000))/100 W=UnitPVPRank("player") N=(W-6)*5000+5000*P/100 Q=(W-5)*5000-N*0.8 SendChatMessage("Rank Progress: "..P.."% ".."Current RP: "..N.." RP to next rank "..Q.."","emote")   
    
 end
 

--- a/MorunoRank/core.lua
+++ b/MorunoRank/core.lua
@@ -83,9 +83,9 @@ function MorunoRank()
     EarnedRank = getCurrentRank(EEarns);
     PercentNextPVPRank=math.floor(((EEarns-getCurrentHP(EarnedRank))*100)/(getCurrentHP(UPVPRank+1)-getCurrentHP(UPVPRank)));
    
-    if(PercentNextPVPRank<0) then PercentNextPVPRank=PercentNextPVPRank*-1;end;
+    if(PercentNextPVPRank<0) then PercentNextPVPRank=PercentNextPVPRank;end;
  
-    SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns..")","emote");
+SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns.." at "..PercentNextPVPRank.."%(Rank "..EarnedRank..")","emote");
 -- SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns.." at "..PercentNextPVPRank.."%(Rank "..EarnedRank..")","emote");
 -- This is a temp fix
    

--- a/MorunoRank/core.lua
+++ b/MorunoRank/core.lua
@@ -85,12 +85,13 @@ function MorunoRank()
    
     if(PercentNextPVPRank<0) then PercentNextPVPRank=PercentNextPVPRank*-1;end;
  
-    SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB)..","emote");
+    SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns.." at "..PercentNextPVPRank.."%(Rank "..EarnedRank..")","emote");
 -- SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns.." at "..PercentNextPVPRank.."%(Rank "..EarnedRank..")","emote");
 -- This is a temp fix
    
 -- This is a reference to a verified calculation. Going to try and incorporate the 'RP gaming this week'. 
 -- /script P=(math.floor(GetPVPRankProgress(target)*10000))/100 W=UnitPVPRank("player") N=(W-6)*5000+5000*P/100 Q=(W-5)*5000-N*0.8 SendChatMessage("Rank Progress: "..P.."% ".."Current RP: "..N.." RP to next rank "..Q.."","emote")   
+end
 end
 
 end)

--- a/MorunoRank/core.lua
+++ b/MorunoRank/core.lua
@@ -85,13 +85,13 @@ function MorunoRank()
    
     if(PercentNextPVPRank<0) then PercentNextPVPRank=PercentNextPVPRank*-1;end;
  
-    SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns.." at "..PercentNextPVPRank.."%(Rank "..EarnedRank..")","emote");
+    SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns.." ","emote");
 -- SendChatMessage("Current RP: "..CurrentRP.." at "..PercentPVPRank.."% (Rank "..CurrentRank..") RP To Next Rank: "..NeededRPToNextRank.." This Week RP Gained:"..math.floor(RB).." @ Total RP Calculation: "..EEarns.." at "..PercentNextPVPRank.."%(Rank "..EarnedRank..")","emote");
--- This is a temp fix
+-- This is a temp fix that removes the PercentNextPVPRank calc
    
 -- This is a reference to a verified calculation. Going to try and incorporate the 'RP gaming this week'. 
 -- /script P=(math.floor(GetPVPRankProgress(target)*10000))/100 W=UnitPVPRank("player") N=(W-6)*5000+5000*P/100 Q=(W-5)*5000-N*0.8 SendChatMessage("Rank Progress: "..P.."% ".."Current RP: "..N.." RP to next rank "..Q.."","emote")   
-end
+
 end
 
 end)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MorunoRank
 This addon calculates current rank points, as well as how much is needed to reach the next rank.
 
-####To install: 
+To install: 
 Extract the folder MorunoRank into your AddOns folder
 
-####To run the script, type this command or create a macro: 
+To run the script, type this command or create a macro: 
 /script MorunoRank();


### PR DESCRIPTION
I removed the PercentNextPVPRank calculation because it doesn't work past R10 (so far from what we've seen). The only thing really difference for the user is they need to know their bracket ceiling. ex: 5000 is R12, 5500 is R13, ect.

It looks like we just need to work on this string: PercentNextPVPRank=math.floor(((EEarnsgetCurrentHP(EarnedRank))*100)/(getCurrentHP(UPVPRank+1)-getCurrentHP(UPVPRank)));

It doesn't look like it's grabbing the current PvP Rank to add to.